### PR TITLE
build: debug openCPN and radar-pi using CMake and GDB

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 FROM ros:humble
-ARG USERNAME=seamate
+ARG USERNAME=seamate-docker
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,10 +22,10 @@
         }
     },
     // port defintiions
-    // 5800 = radar locate
-    // 3594 = radar data
-    // 3850 = radar command
-    // 20000 = radio
+    // 5800 = radar locate (working)
+    // 2575, 3594 = radar data ?
+    // 2575, 3850 = radar command ?
+    // 20000 = radio (arbitrarily selected)
     "appPort": ["5800:5800/udp", "2575:2575/udp", "3850:3850/udp", "3594:3594/udp", "20000:20000/udp", "20000:20000/tcp"],
     // "containerEnv": {
     //     "DISPLAY": "localhost:0",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,10 +23,10 @@
     },
     // port defintiions
     // 5800 = radar locate
-    // 2575 = radar data
-    // 2575 = radar command
+    // 3594 = radar data
+    // 3850 = radar command
     // 20000 = radio
-    "appPort": ["5800:5800/udp", "2574:2574/udp", "2575:2575/udp", "20000:20000/udp", "20000:20000/tcp"],
+    "appPort": ["5800:5800/udp", "2575:2575/udp", "3850:3850/udp", "3594:3594/udp", "20000:20000/udp", "20000:20000/tcp"],
     // "containerEnv": {
     //     "DISPLAY": "localhost:0",
     //     "ROS_AUTOMATIC_DISCOVERY_RANGE": "LOCALHOST",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,5 +43,5 @@
     //     "source=${localWorkspaceFolder}/cache/iron/install,target=/home/ws/install,type=bind",
     //     "source=${localWorkspaceFolder}/cache/iron/log,target=/home/ws/log,type=bind"
     // ],
-    "postCreateCommand": "bash .devcontainer/env-setup.sh"
+    "postCreateCommand": "echo \"source /opt/ros/$ROS_DISTRO/setup.bash\" >> ~/.bashrc && rosdep update && rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y    "
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
     "name": "ROS 2 Development Container",
     "privileged": true,
-    "remoteUser": "seamate",
+    "remoteUser": "seamate-docker",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "USERNAME": "seamate"
+            "USERNAME": "seamate-docker"
         }
     },
     "workspaceFolder": "/home/ws",

--- a/.devcontainer/env-setup.sh
+++ b/.devcontainer/env-setup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
-rosdep update
-rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y
-
-# Uncomment below lines to install ROS turtle tutorial after creating dev container
-# sudo apt update
-# sudo apt install -y ros-humble-turtlesim ~nros-humble-rqt*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,21 @@
+# ROS colcon build folders
 build/
 install/
 log/
-.vscode/
+
+# VScode config
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,9 @@
 	path = src/examples
 	url = https://github.com/ros2/examples
 	branch = humble
+[submodule "OpenCPN"]
+	path = OpenCPN
+	url = https://github.com/OpenCPN/OpenCPN.git
+[submodule "radar_pi"]
+	path = radar_pi
+	url = https://github.com/opencpn-radar-pi/radar_pi.git

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,52 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "/usr/local/bin/opencpn",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "(gdb) Attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "/usr/local/bin/opencpn",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Environment setup is based on [ROS2 Community Guide](https://docs.ros.org/en/hum
 4. Wait for container to install
 
 ## Building ros_tutorial package
-1. run `git submodule update --init --recursive` to pull the ros_tutorials repository
+1. run `git submodule update --init --recursive` to clone all the submodules
 2. run `colcon build`

--- a/debug-opencpn.sh
+++ b/debug-opencpn.sh
@@ -2,7 +2,7 @@
 
 cd OpenCPN
 
-sudo apt install devscripts equivs
+sudo apt install devscripts equivs gdb
 sudo mk-build-deps -i -r ci/control
 sudo apt-get --allow-unauthenticated install -f
 

--- a/debug-opencpn.sh
+++ b/debug-opencpn.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd OpenCPN
+
+sudo apt install devscripts equivs
+sudo mk-build-deps -i -r ci/control
+sudo apt-get --allow-unauthenticated install -f
+
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j `nproc`
+sudo cmake --install build

--- a/debug-radar-pi.sh
+++ b/debug-radar-pi.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd radar_pi
+
+sudo apt install devscripts equivs
+sudo mk-build-deps -i -r ci/control
+sudo apt-get --allow-unauthenticated install -f
+
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j `nproc`

--- a/debug-radar-pi.sh
+++ b/debug-radar-pi.sh
@@ -2,7 +2,7 @@
 
 cd radar_pi
 
-sudo apt install devscripts equivs
+sudo apt install devscripts equivs gdb
 sudo mk-build-deps -i -r ci/control
 sudo apt-get --allow-unauthenticated install -f
 

--- a/notes/meeting.txt
+++ b/notes/meeting.txt
@@ -1,0 +1,6 @@
+1992  cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+ 1993  cmake --build build -j `nproc`
+ 1994  sudo cmake --install build
+
+ https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:install_and_enable#plugin_package_installation_removal_pi
+ 

--- a/scripts/build-opencpn.sh
+++ b/scripts/build-opencpn.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Script for building and installing openCPN with debug flag
 
-cd radar_pi
+cd /home/ws/OpenCPN
 
 sudo apt install devscripts equivs gdb
 sudo mk-build-deps -i -r ci/control
@@ -8,3 +9,4 @@ sudo apt-get --allow-unauthenticated install -f
 
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j `nproc`
+sudo cmake --install build

--- a/scripts/build-radar-pi.sh
+++ b/scripts/build-radar-pi.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Script for building radar-pi with debug flag
 
-cd OpenCPN
+cd /home/ws/radar_pi
 
 sudo apt install devscripts equivs gdb
 sudo mk-build-deps -i -r ci/control
@@ -8,4 +9,3 @@ sudo apt-get --allow-unauthenticated install -f
 
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j `nproc`
-sudo cmake --install build

--- a/src/radar/radar/control.py
+++ b/src/radar/radar/control.py
@@ -7,7 +7,8 @@ import logging
 logging.basicConfig(level=logging.DEBUG) # Uncomment to enable debug logging
 
 HOST = '192.168.1.117'        # The remote host
-PORT = 2575                 # The same port as used by the server
+# PORT = 2575                 # The same port as used by the server
+PORT = 3850                 # The same port as used by the server
 RADAR_ADDR = (HOST, PORT)
 
 TIMEOUT_IN_SECONDS = 1

--- a/src/radar/radar/receive.py
+++ b/src/radar/radar/receive.py
@@ -8,6 +8,7 @@ logging.basicConfig(level=logging.INFO)
 def main():
     MULTICAST_GROUP = '232.1.179.1'
     MULTICAST_PORT = 2574
+    # MULTICAST_PORT = 3594
 
     # Create the socket
     with socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM, proto=socket.IPPROTO_UDP) as sock:


### PR DESCRIPTION
Changes:
- Cloned openCPN and radar-pi repository as submodule to root of the repository
- Fixed issue with devcontainer initialization shell script erroring out
- Create debug launch configuration file to enable debugging with vscode
- Add one-liner shell script for building opencpn and radar-pi