### PR TITLE
feat: receive radar scan data through UDP multicast after turning on radar

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,15 +27,15 @@
     // 2575 = radar command
     // 20000 = radio (arbitrarily selected)
     "appPort": ["5800:5800/udp", "2575:2575/udp", "2574:2574/udp", "20000:20000/udp", "20000:20000/tcp"],
+    "runArgs": [
+        "--net=host",
+        "-e", "DISPLAY=${env:DISPLAY}"
+    ],
     // "containerEnv": {
     //     "DISPLAY": "localhost:0",
     //     "ROS_AUTOMATIC_DISCOVERY_RANGE": "LOCALHOST",
     //     "ROS_DOMAIN_ID": "42"
     // },
-    // "runArgs": [
-        // "--net=host",
-        // "-e", "DISPLAY=${env:DISPLAY}"
-    // ],
     // "mounts": [
     //     // "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
     //     // "source=/dev/dri,target=/dev/dri,type=bind,consistency=cached",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,10 +23,10 @@
     },
     // port defintiions
     // 5800 = radar locate (working)
-    // 2574, 3594 = radar data ?
-    // 2575, 3850 = radar command ?
+    // 2574 = radar data
+    // 2575 = radar command
     // 20000 = radio (arbitrarily selected)
-    "appPort": ["5800:5800/udp", "2575:2575/udp", "2574:2574/udp", "3850:3850/udp", "3594:3594/udp", "20000:20000/udp", "20000:20000/tcp"],
+    "appPort": ["5800:5800/udp", "2575:2575/udp", "2574:2574/udp", "20000:20000/udp", "20000:20000/tcp"],
     // "containerEnv": {
     //     "DISPLAY": "localhost:0",
     //     "ROS_AUTOMATIC_DISCOVERY_RANGE": "LOCALHOST",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,5 +43,5 @@
     //     "source=${localWorkspaceFolder}/cache/iron/install,target=/home/ws/install,type=bind",
     //     "source=${localWorkspaceFolder}/cache/iron/log,target=/home/ws/log,type=bind"
     // ],
-    "postCreateCommand": "echo \"source /opt/ros/$ROS_DISTRO/setup.bash\" >> ~/.bashrc && rosdep update && rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y"
+    "postCreateCommand": "bash .devcontainer/env-setup.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,10 +23,10 @@
     },
     // port defintiions
     // 5800 = radar locate (working)
-    // 2575, 3594 = radar data ?
+    // 2574, 3594 = radar data ?
     // 2575, 3850 = radar command ?
     // 20000 = radio (arbitrarily selected)
-    "appPort": ["5800:5800/udp", "2575:2575/udp", "3850:3850/udp", "3594:3594/udp", "20000:20000/udp", "20000:20000/tcp"],
+    "appPort": ["5800:5800/udp", "2575:2575/udp", "2574:2574/udp", "3850:3850/udp", "3594:3594/udp", "20000:20000/udp", "20000:20000/tcp"],
     // "containerEnv": {
     //     "DISPLAY": "localhost:0",
     //     "ROS_AUTOMATIC_DISCOVERY_RANGE": "LOCALHOST",

--- a/.devcontainer/env-setup.sh
+++ b/.devcontainer/env-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo \"source /opt/ros/$ROS_DISTRO/setup.bash\" >> ~/.bashrc
+rosdep update
+rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y

--- a/.devcontainer/env-setup.sh
+++ b/.devcontainer/env-setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-echo \"source /opt/ros/$ROS_DISTRO/setup.bash\" >> ~/.bashrc
+echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 rosdep update
 rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,42 @@
+{
+    "python.autoComplete.extraPaths": [
+        "/home/ws/install/turtlesim/lib/python3.10/site-packages",
+        "/home/ws/install/radio/lib/python3.10/site-packages",
+        "/home/ws/build/radar",
+        "/home/ws/install/radar/lib/python3.10/site-packages",
+        "/home/ws/install/py_srvcli/lib/python3.10/site-packages",
+        "/home/ws/install/py_pubsub/lib/python3.10/site-packages",
+        "/home/ws/install/launch_testing_examples/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_pointcloud_publisher/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_subscriber/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_service/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_publisher/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_client/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_action_server/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_action_client/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_guard_conditions/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_executors/lib/python3.10/site-packages",
+        "/opt/ros/humble/lib/python3.10/site-packages",
+        "/opt/ros/humble/local/lib/python3.10/dist-packages"
+    ],
+    "python.analysis.extraPaths": [
+        "/home/ws/install/turtlesim/lib/python3.10/site-packages",
+        "/home/ws/install/radio/lib/python3.10/site-packages",
+        "/home/ws/build/radar",
+        "/home/ws/install/radar/lib/python3.10/site-packages",
+        "/home/ws/install/py_srvcli/lib/python3.10/site-packages",
+        "/home/ws/install/py_pubsub/lib/python3.10/site-packages",
+        "/home/ws/install/launch_testing_examples/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_pointcloud_publisher/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_subscriber/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_service/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_publisher/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_client/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_action_server/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_minimal_action_client/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_guard_conditions/lib/python3.10/site-packages",
+        "/home/ws/install/examples_rclpy_executors/lib/python3.10/site-packages",
+        "/opt/ros/humble/lib/python3.10/site-packages",
+        "/opt/ros/humble/local/lib/python3.10/dist-packages"
+    ]
+}

--- a/notes/meeting.txt
+++ b/notes/meeting.txt
@@ -1,6 +1,8 @@
-1992  cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
- 1993  cmake --build build -j `nproc`
- 1994  sudo cmake --install build
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j `nproc`
+sudo cmake --install build
 
- https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:install_and_enable#plugin_package_installation_removal_pi
+https://opencpn-manuals.github.io/main/opencpn-dev/linux.html#_2_install_build_dependencies
+https://opencpn-manuals.github.io/main/AlternativeWorkflow/Local-Build.html
+https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:install_and_enable#plugin_package_installation_removal_pi
  

--- a/notes/meeting.txt
+++ b/notes/meeting.txt
@@ -5,4 +5,4 @@ sudo cmake --install build
 https://opencpn-manuals.github.io/main/opencpn-dev/linux.html#_2_install_build_dependencies
 https://opencpn-manuals.github.io/main/AlternativeWorkflow/Local-Build.html
 https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual:plugins:install_and_enable#plugin_package_installation_removal_pi
- 
+https://www.xmodulo.com/how-to-capture-and-replay-network-traffic-on-linux.html

--- a/scripts/build-opencpn.sh
+++ b/scripts/build-opencpn.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Script for building and installing openCPN with debug flag
 
+git submodule update --init --recursive OpenCPN
 cd /home/ws/OpenCPN
 
-sudo apt install devscripts equivs gdb
+sudo apt install devscripts equivs gdb -y
 sudo mk-build-deps -i -r ci/control
 sudo apt-get --allow-unauthenticated install -f
 

--- a/scripts/build-radar-pi.sh
+++ b/scripts/build-radar-pi.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Script for building radar-pi with debug flag
 
+git submodule update --init --recursive radar_pi
 cd /home/ws/radar_pi
 
-sudo apt install devscripts equivs gdb
+sudo apt install devscripts equivs gdb -y
 sudo mk-build-deps -i -r ci/control
 sudo apt-get --allow-unauthenticated install -f
 

--- a/src/radar/radar/control.py
+++ b/src/radar/radar/control.py
@@ -7,8 +7,8 @@ import logging
 logging.basicConfig(level=logging.DEBUG) # Uncomment to enable debug logging
 
 HOST = '192.168.1.117'        # The remote host
-# PORT = 2575                 # The same port as used by the server
-PORT = 3850                 # The same port as used by the server
+PORT = 2575                 # The same port as used by the server
+# PORT = 3850                 # The same port as used by the server
 RADAR_ADDR = (HOST, PORT)
 
 TIMEOUT_IN_SECONDS = 1

--- a/src/radar/radar/control.py
+++ b/src/radar/radar/control.py
@@ -8,7 +8,6 @@ logging.basicConfig(level=logging.DEBUG) # Uncomment to enable debug logging
 
 HOST = '192.168.1.117'        # The remote host
 PORT = 2575                 # The same port as used by the server
-# PORT = 3850                 # The same port as used by the server
 RADAR_ADDR = (HOST, PORT)
 
 TIMEOUT_IN_SECONDS = 1

--- a/src/radar/radar/receive.py
+++ b/src/radar/radar/receive.py
@@ -8,7 +8,6 @@ logging.basicConfig(level=logging.DEBUG)
 def main():
     MULTICAST_GROUP = '232.1.179.1'
     MULTICAST_PORT = 2574
-    # MULTICAST_PORT = 3594
 
     # Create the socket
     with socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM, proto=socket.IPPROTO_UDP) as sock:

--- a/src/radar/radar/receive.py
+++ b/src/radar/radar/receive.py
@@ -3,7 +3,7 @@ import socket
 import struct
 import logging
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 def main():
     MULTICAST_GROUP = '232.1.179.1'


### PR DESCRIPTION
Successfully receive radar scan data over multicast addr 232.1.179.1:2574 after turning on the radar.

Demo:
1. Build radar ros package
2. Run radar "alive" node
3. Run radar "on" node
4. Run radar "receive" node
5. Observe receive node printing radar scan data

Note that program only works if the devcontainers is in "host network mode" (only available on linux). Tested code works on both CE linux-desktop and on rpi2.