### PR TITLE
build: do not run rosdep after creating container

### DIFF
--- a/.devcontainer/env-setup.sh
+++ b/.devcontainer/env-setup.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
 echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
-rosdep update
-rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y

--- a/scripts/rosdep.sh
+++ b/scripts/rosdep.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+rosdep update
+rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y


### PR DESCRIPTION
rosdep command always runs after devcontainer initialization, but it's too slow.
I'm moving the two commands into a seperate script that users can call on their own.